### PR TITLE
WIP Uppercase macros

### DIFF
--- a/examples/html.janet
+++ b/examples/html.janet
@@ -18,11 +18,11 @@
 
     (eachp [k v] body
       (put-in output [k]
-              (cond
-                (= "false" v) false
-                (= "true" v) true
-                (peg/match :d+ v) (scan-number v)
-                :else v)))
+        (cond
+          (= "false" v) false
+          (= "true" v) true
+          (peg/match :d+ v) (scan-number v)
+          :else v)))
 
     output))
 
@@ -30,97 +30,97 @@
 # before all requests try to parse application/x-www-form-urlencoded body
 # and use naive coerce fn
 (before "*"
-        (-> request
-            (update :body form/decode)
-            (update :body coerce)
-            (update :params coerce)))
+  (-> request
+      (update :body form/decode)
+      (update :body coerce)
+      (update :params coerce)))
 
 
 # before "/todos/:id"
 # set the id and todo var
 (before "/todos/*"
-        (when (params :id)
-          (set! id (params :id)))
-        (set! todo (todos id)))
+  (when (params :id)
+    (set! id (params :id)))
+  (set! todo (todos id)))
 
 
 # after any request that isn't a redirect, slap a layout and html encode
 (after "*"
-       (if (dictionary? response)
-         response
-         (html/encode
-           (doctype :html5)
-           [:html {:lang "en"}
-            [:head
-             [:title (request :uri)]]
-            [:body response]])))
+  (if (dictionary? response)
+    response
+    (html/encode
+      (doctype :html5)
+      [:html {:lang "en"}
+        [:head
+         [:title (request :uri)]]
+        [:body response]])))
 
 
 (GET "/"
-     [:div
-      [:h1 "welcome to osprey"]
-      [:a {:href "/todos"} "view todos"]])
+  [:div
+   [:h1 "welcome to osprey"]
+   [:a {:href "/todos"} "view todos"]])
 
 
 # list of todos
 (GET "/todos"
-     [:div
-      [:a {:href "/"} "go home"]
-      [:span " "]
-      [:a {:href "/todo"} "new todo"]
-      [:ul
-       (foreach [todo (->> todos values (sort-by |($ :id)))]
-                [:li
-                 [:span (todo :name)]
-                 [:span (if (todo :done) " is done!" "")]
-                 [:div
-                  [:a {:href (href "/todos/:id/edit" todo)}
-                   "edit"]
-                  [:span " "]
-                  (form "/todos/:id/delete" todo
-                        [:input {:type "submit" :value "delete"}])]])]])
+  [:div
+   [:a {:href "/"} "go home"]
+   [:span " "]
+   [:a {:href "/todo"} "new todo"]
+   [:ul
+    (foreach [todo (->> todos values (sort-by |($ :id)))]
+      [:li
+       [:span (todo :name)]
+       [:span (if (todo :done) " is done!" "")]
+       [:div
+        [:a {:href (href "/todos/:id/edit" todo)}
+          "edit"]
+        [:span " "]
+        (form "/todos/:id/delete" todo
+         [:input {:type "submit" :value "delete"}])]])]])
 
 
 (GET "/todos/:id"
-     [:div
-      [:span (todo :name)]
-      [:span (if (todo :done) " is done!" "")]])
+  [:div
+   [:span (todo :name)]
+   [:span (if (todo :done) " is done!" "")]])
 
 
 (GET "/todo"
-     (form "/todos"
-           [:input {:type "text" :name "name"}]
-           [:input {:type "hidden" :name "done" :value false}]
-           [:input {:type "checkbox" :name "done" :value true}]
-           [:input {:type "submit" :value "Save"}]))
+  (form "/todos"
+   [:input {:type "text" :name "name"}]
+   [:input {:type "hidden" :name "done" :value false}]
+   [:input {:type "checkbox" :name "done" :value true}]
+   [:input {:type "submit" :value "Save"}]))
 
 
 (POST "/todos"
-      (let [id (-> todos keys length)
-            todo (put-in body [:id] id)]
-        (put-in todos [id] todo))
+  (let [id (-> todos keys length)
+        todo (put-in body [:id] id)]
+    (put-in todos [id] todo))
 
-      (redirect "/todos"))
+  (redirect "/todos"))
 
 
 (GET "/todos/:id/edit"
-     (form "/todos/:id/update" todo
-           [:input {:type "text" :name "name" :value (todo :name)}]
-           [:input {:type "hidden" :name "done" :value false}]
-           [:input (merge {:type "checkbox" :name "done" :value true} (if (todo :done) {:checked ""} {}))]
-           [:input {:type "submit" :value "Save"}]))
+  (form "/todos/:id/update" todo
+   [:input {:type "text" :name "name" :value (todo :name)}]
+   [:input {:type "hidden" :name "done" :value false}]
+   [:input (merge {:type "checkbox" :name "done" :value true} (if (todo :done) {:checked ""} {}))]
+   [:input {:type "submit" :value "Save"}]))
 
 
 # this updates todos in the dictionary
 (POST "/todos/:id/update"
-      (update todos id merge body)
-      (redirect "/todos"))
+  (update todos id merge body)
+  (redirect "/todos"))
 
 
 # this deletes todos from the dictionary
 (POST "/todos/:id/delete"
-      (put-in todos [id] nil)
-      (redirect "/todos"))
+  (put-in todos [id] nil)
+  (redirect "/todos"))
 
 
 # start the server on port 9001

--- a/examples/html.janet
+++ b/examples/html.janet
@@ -17,7 +17,7 @@
     (var output @{})
 
     (eachp [k v] body
-      (put-in output [k]
+      (put output k
         (cond
           (= "false" v) false
           (= "true" v) true
@@ -97,8 +97,8 @@
 
 (POST "/todos"
   (let [id (-> todos keys length)
-        todo (put-in body [:id] id)]
-    (put-in todos [id] todo))
+        todo (put body :id id)]
+    (put todos id todo))
 
   (redirect "/todos"))
 
@@ -119,7 +119,7 @@
 
 # this deletes todos from the dictionary
 (POST "/todos/:id/delete"
-  (put-in todos [id] nil)
+  (put todos id nil)
   (redirect "/todos"))
 
 

--- a/src/osprey/router.janet
+++ b/src/osprey/router.janet
@@ -54,7 +54,7 @@
   (array/push *routes* [method uri f]))
 
 
-(defmacro get
+(defmacro GET
   [uri & *osprey-args*]
   (with-syms [$uri]
     ~(let [,$uri ,uri]
@@ -67,7 +67,7 @@
                        (do ,;*osprey-args*)))))))
 
 
-(defmacro post
+(defmacro POST
   [uri & *osprey-args*]
   (with-syms [$uri]
     ~(let [,$uri ,uri]
@@ -80,7 +80,7 @@
                        (do ,;*osprey-args*)))))))
 
 
-(defmacro put
+(defmacro PUT
   [uri & *osprey-args*]
   (with-syms [$uri]
     ~(let [,$uri ,uri]
@@ -93,7 +93,7 @@
                        (do ,;*osprey-args*)))))))
 
 
-(defmacro patch
+(defmacro PATCH
   [uri & *osprey-args*]
   (with-syms [$uri]
     ~(let [,$uri ,uri]
@@ -106,7 +106,7 @@
                        (do ,;*osprey-args*)))))))
 
 
-(defmacro delete
+(defmacro DELETE
   [uri & *osprey-args*]
   (with-syms [$uri]
     ~(let [,$uri ,uri]

--- a/test/osprey-test.janet
+++ b/test/osprey-test.janet
@@ -1,5 +1,5 @@
 (use ../src/osprey)
 
-(get "/" "osprey")
+(GET "/" "osprey")
 
 (server 9001)


### PR DESCRIPTION
Here is the first shot on uppercasing of the HTTP verbs. Only macros in `router.janet`, html.janet example and test are ready for now. In the example I also get rid of the ugly -in a hack, so you can see it really is so much nicer :-).

If you accept this change, I would finish all the examples and docs in this new spirit.

Also, have you considered to format the code with spork/fmt? I admit, that the code looks nicer when macros behave more like specials (indent on next line), but I like the consistency of format. The changed and reverted formatting could be seen in `html.janet` example namely 27604ee 

The more I know osprey, the more I like it!