### PR TITLE
Add cipher dependency

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -2,6 +2,7 @@
   :name "osprey"
   :description "A sinatra inspired web framework for janet"
   :dependencies ["https://github.com/joy-framework/halo2"
+                 "https://github.com/joy-framework/cipher"
                  "https://github.com/andrewchambers/janet-uri"
                  "https://github.com/janet-lang/path"]
   :author "Sean Walker"
@@ -11,4 +12,3 @@
 
 (declare-source
   :source @["src/osprey" "src/osprey.janet"])
-


### PR DESCRIPTION
There are also `:url` and `:repo` set to nonexistent ones in the project.janet, but it is not part of this commit.